### PR TITLE
chore: logs viewer scrollbar min height to 20%

### DIFF
--- a/src/renderer/pages/HomePage.tsx
+++ b/src/renderer/pages/HomePage.tsx
@@ -214,7 +214,6 @@ const LogContainer = styled.div`
 
     &::-webkit-scrollbar {
         width: 0.69rem;
-        height: 0.69em;
     }
 
     &::-webkit-scrollbar-track {
@@ -223,6 +222,7 @@ const LogContainer = styled.div`
 
     &::-webkit-scrollbar-thumb {
         background: ${(props) => props.theme.color.background3};
+        min-height: 20%;
     }
 `;
 


### PR DESCRIPTION
Pull request checklist:

-   [x] `CHANGELOG.md` was updated, if applicable (N/A)
-   [x] Add `Fixes #(issue)` if applicable (N/A)

# Description

Logs viewer scrollbar to have a minimum height of 20% of the logs viewer container height so that when there are a lot of logs, the scrollbar will still have a certain height and won't be too small.